### PR TITLE
feat: remove header & footer from registration pages

### DIFF
--- a/public/styles/auth.css
+++ b/public/styles/auth.css
@@ -133,6 +133,11 @@ aside>img {
     padding: 2%;
 }
 
+header,
+footer {
+    display: none;
+}
+
 @media (max-width: 700px) {
     aside {
         display: none;


### PR DESCRIPTION
To stay true to the figma maquette